### PR TITLE
Add tagged in-place constructors to error_or.

### DIFF
--- a/include/mstd/error_or.hpp
+++ b/include/mstd/error_or.hpp
@@ -128,8 +128,11 @@ public:
 
 	// Implicit conversions from both Error and T.
 
+	template<bool B=1, typename=std::enable_if_t<B && !std::is_same<T, Error>{}>>
 	error_or(Error e) : error_or{invalid, std::move(e)} {}
-	error_or(T value) : error_or{valid,   static_cast<T &&>(value)} {}
+
+	template<char B=1, typename=std::enable_if_t<B && !std::is_same<T, Error>{}>>
+	error_or(T value) : error_or{valid, static_cast<T &&>(value)} {}
 
 	// Move and copy constructors.
 


### PR DESCRIPTION
This PR adds tagged constructors for `error_or`. It allows unambiguous construction when a type is convertible to both `T` and `E`. One situation where this can't be solved by manually converting to `T` or `E` is when `T == E`.

It also implements the regular conversion constructors by delegating to these in-place constructors. I couldn't really think of a reason not to do that.

The names for the tags are `valid` and `invalid`. We can discuss alternate names for the tags if you don't like them. I also considered `success` and `error`, but they seemed a bit too generic.

It is possible to hide the tags from the user and expose static member functions instead, but that gets much more verbose.

Another option is to have free functions that return a proxy object that can be converted to an `error_or` using (possibly private) tagged constructors. That is quite a bit more complicated than just having tagged constructors though.